### PR TITLE
Add release/tag workflow and GitHub Packages publishing

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION='${{ steps.version.outputs.version }}'
-          sed -i -E "s#^(de-janschuri-lunaticlib\s*=\s*").*(")#\1${VERSION}\2#" gradle/libs.versions.toml
+          sed -i -E 's#^(de-janschuri-lunaticlib\s*=\s*").*(")#\1'"$VERSION"'\2#' gradle/libs.versions.toml
           grep -n '^de-janschuri-lunaticlib\s*=\s*"' gradle/libs.versions.toml
 
       - name: Build all modules and fat jars

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -42,39 +42,42 @@ jobs:
           SHORT_SHA="${GITHUB_SHA::7}"
 
           if [[ "$BRANCH_NAME" == "main" ]]; then
-            VERSION="$BASE_VERSION"
             TAG="v$BASE_VERSION"
+            VERSION="$BASE_VERSION"
             CREATE_RELEASE="true"
-
-            if ! git rev-parse "$TAG" >/dev/null 2>&1; then
-              git tag "$TAG" "$GITHUB_SHA"
-              git push origin "$TAG"
-            fi
           else
             SAFE_BRANCH=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9._-]#-#g')
-            VERSION="${BASE_VERSION}-${SAFE_BRANCH}.${GITHUB_RUN_NUMBER}.${SHORT_SHA}"
             TAG="ci/${SAFE_BRANCH}/${SHORT_SHA}"
+            VERSION="${BASE_VERSION}-${SAFE_BRANCH}.${GITHUB_RUN_NUMBER}.${SHORT_SHA}"
             CREATE_RELEASE="false"
+          fi
 
-            if ! git rev-parse "$TAG" >/dev/null 2>&1; then
-              git tag "$TAG" "$GITHUB_SHA"
-              git push origin "$TAG"
-            fi
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            git tag "$TAG" "$GITHUB_SHA"
+            git push origin "$TAG"
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "create_release=$CREATE_RELEASE" >> "$GITHUB_OUTPUT"
 
-      - name: Build fat jars
-        run: ./gradlew --no-daemon clean lunaticlibPaperFatJar lunaticlibVelocityFatJar lunaticlibWaterfallFatJar -PlunaticlibVersion=${{ steps.version.outputs.version }}
+      - name: Update version in gradle/libs.versions.toml
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION='${{ steps.version.outputs.version }}'
+          sed -i -E "s#^(de-janschuri-lunaticlib\s*=\s*").*(")#\1${VERSION}\2#" gradle/libs.versions.toml
+          grep -n '^de-janschuri-lunaticlib\s*=\s*"' gradle/libs.versions.toml
 
-      - name: Publish to GitHub Packages
+      - name: Build all modules and fat jars
+        run: ./gradlew --no-daemon clean build
+
+      - name: Publish all modules and fat jars to GitHub Packages
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: ./gradlew --no-daemon publish -PlunaticlibVersion=${{ steps.version.outputs.version }}
+        run: ./gradlew --no-daemon publish
 
       - name: Create GitHub Release (main only)
         if: steps.version.outputs.create_release == 'true'

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -1,0 +1,89 @@
+name: Release and Publish
+
+on:
+  push:
+    branches:
+      - '**'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Compute version and tag
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BASE_VERSION=$(sed -nE 's/^de-janschuri-lunaticlib\s*=\s*"([^"]+)"/\1/p' gradle/libs.versions.toml | head -n 1)
+          if [[ -z "$BASE_VERSION" ]]; then
+            echo "Could not determine base version from gradle/libs.versions.toml"
+            exit 1
+          fi
+
+          BRANCH_NAME="${GITHUB_REF_NAME}"
+          SHORT_SHA="${GITHUB_SHA::7}"
+
+          if [[ "$BRANCH_NAME" == "main" ]]; then
+            VERSION="$BASE_VERSION"
+            TAG="v$BASE_VERSION"
+            CREATE_RELEASE="true"
+
+            if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+              git tag "$TAG" "$GITHUB_SHA"
+              git push origin "$TAG"
+            fi
+          else
+            SAFE_BRANCH=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9._-]#-#g')
+            VERSION="${BASE_VERSION}-${SAFE_BRANCH}.${GITHUB_RUN_NUMBER}.${SHORT_SHA}"
+            TAG="ci/${SAFE_BRANCH}/${SHORT_SHA}"
+            CREATE_RELEASE="false"
+
+            if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+              git tag "$TAG" "$GITHUB_SHA"
+              git push origin "$TAG"
+            fi
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "create_release=$CREATE_RELEASE" >> "$GITHUB_OUTPUT"
+
+      - name: Build fat jars
+        run: ./gradlew --no-daemon clean lunaticlibPaperFatJar lunaticlibVelocityFatJar lunaticlibWaterfallFatJar -PlunaticlibVersion=${{ steps.version.outputs.version }}
+
+      - name: Publish to GitHub Packages
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./gradlew --no-daemon publish -PlunaticlibVersion=${{ steps.version.outputs.version }}
+
+      - name: Create GitHub Release (main only)
+        if: steps.version.outputs.create_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1 || \
+            gh release create "${{ steps.version.outputs.tag }}" build/libs/*.jar \
+              --title "Release ${{ steps.version.outputs.tag }}" \
+              --generate-notes

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,11 @@ subprojects {
     apply(plugin = "java-library")
     apply(plugin = "maven-publish")
 
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+
     publishing {
         publications {
             create<MavenPublication>("mavenJava") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,10 +5,12 @@ plugins {
 }
 
 val lunaticlibVersion: String by lazy {
-    val tomlFile = file("gradle/libs.versions.toml")
-    val versionRegex = Regex("""de-janschuri-lunaticlib\s*=\s*"([^"]+)"""")
-    tomlFile.readLines()
-        .firstNotNullOf { versionRegex.find(it)?.groupValues?.get(1) }
+    providers.gradleProperty("lunaticlibVersion").orNull ?: run {
+        val tomlFile = file("gradle/libs.versions.toml")
+        val versionRegex = Regex("""de-janschuri-lunaticlib\s*=\s*"([^"]+)"""")
+        tomlFile.readLines()
+            .firstNotNullOf { versionRegex.find(it)?.groupValues?.get(1) }
+    }
 }
 extra["lunaticlibVersion"] = lunaticlibVersion
 
@@ -18,6 +20,27 @@ version = lunaticlibVersion
 repositories {
     mavenLocal()
     mavenCentral()
+}
+
+fun org.gradle.api.publish.PublishingExtension.configurePublishRepositories() {
+    repositories {
+        mavenLocal()
+
+        val githubActor = System.getenv("GITHUB_ACTOR")
+        val githubToken = System.getenv("GITHUB_TOKEN")
+        val githubRepository = System.getenv("GITHUB_REPOSITORY")
+
+        if (!githubActor.isNullOrBlank() && !githubToken.isNullOrBlank() && !githubRepository.isNullOrBlank()) {
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/$githubRepository")
+                credentials {
+                    username = githubActor
+                    password = githubToken
+                }
+            }
+        }
+    }
 }
 
 subprojects {
@@ -30,10 +53,7 @@ subprojects {
                 from(components["java"])
             }
         }
-
-        repositories {
-            mavenLocal()
-        }
+        configurePublishRepositories()
     }
 }
 
@@ -121,9 +141,7 @@ publishing {
         }
     }
 
-    repositories {
-        mavenLocal()
-    }
+    configurePublishRepositories()
 }
 
 tasks.register("publishAllModulesToMavenLocal") {


### PR DESCRIPTION
### Motivation
- Provide automated releases and deterministic CI tagging for every push while publishing built artifacts to GitHub Packages.
- Allow CI to control the published version so non-`main` pushes can publish uniquely-versioned SNAPSHOT-like artifacts.

### Description
- Add GitHub Actions workflow at ` .github/workflows/release-and-publish.yml` that runs on every push, computes a version from `gradle/libs.versions.toml`, tags commits (`v<version>` on `main`, `ci/<branch>/<sha7>` on others), builds all fat JARs, publishes to GitHub Packages, and creates a GitHub Release for `main`.
- Update `build.gradle.kts` so `lunaticlibVersion` can be overridden via `-PlunaticlibVersion=...` while falling back to `gradle/libs.versions.toml` when not provided.
- Add a helper `configurePublishRepositories()` in `build.gradle.kts` that keeps `mavenLocal()` and conditionally configures the GitHub Packages repository using `GITHUB_ACTOR`, `GITHUB_TOKEN`, and `GITHUB_REPOSITORY`; apply it to subproject and root publications.
- Ensure fat-jar publications (`paper`, `velocity`, `waterfall`) are published using the configured repositories and the computed/overridden version.

### Testing
- Ran `./gradlew --no-daemon help -PlunaticlibVersion=0.0.0-test` to validate the Gradle configuration, and the command failed in this environment with an unrelated Gradle/runtime error (`* What went wrong: 25.0.1`).
- The workflow file and `build.gradle.kts` changes were applied and inspected for correctness in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992459f99dc832884fbbff58aabcedc)