### PR TITLE
Add PaperMC repository and centralize publishing repositories

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -1,0 +1,92 @@
+name: Release and Publish
+
+on:
+  push:
+    branches:
+      - '**'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Compute version and tag
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BASE_VERSION=$(sed -nE 's/^de-janschuri-lunaticlib\s*=\s*"([^"]+)"/\1/p' gradle/libs.versions.toml | head -n 1)
+          if [[ -z "$BASE_VERSION" ]]; then
+            echo "Could not determine base version from gradle/libs.versions.toml"
+            exit 1
+          fi
+
+          BRANCH_NAME="${GITHUB_REF_NAME}"
+          SHORT_SHA="${GITHUB_SHA::7}"
+
+          if [[ "$BRANCH_NAME" == "main" ]]; then
+            TAG="v$BASE_VERSION"
+            VERSION="$BASE_VERSION"
+            CREATE_RELEASE="true"
+          else
+            SAFE_BRANCH=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9._-]#-#g')
+            TAG="ci/${SAFE_BRANCH}/${SHORT_SHA}"
+            VERSION="${BASE_VERSION}-${SAFE_BRANCH}.${GITHUB_RUN_NUMBER}.${SHORT_SHA}"
+            CREATE_RELEASE="false"
+          fi
+
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            git tag "$TAG" "$GITHUB_SHA"
+            git push origin "$TAG"
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "create_release=$CREATE_RELEASE" >> "$GITHUB_OUTPUT"
+
+      - name: Update version in gradle/libs.versions.toml
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION='${{ steps.version.outputs.version }}'
+          sed -i -E "s#^(de-janschuri-lunaticlib\s*=\s*").*(")#\1${VERSION}\2#" gradle/libs.versions.toml
+          grep -n '^de-janschuri-lunaticlib\s*=\s*"' gradle/libs.versions.toml
+
+      - name: Build all modules and fat jars
+        run: ./gradlew --no-daemon clean build
+
+      - name: Publish all modules and fat jars to GitHub Packages
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./gradlew --no-daemon publish
+
+      - name: Create GitHub Release (main only)
+        if: steps.version.outputs.create_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1 || \
+            gh release create "${{ steps.version.outputs.tag }}" build/libs/*.jar \
+              --title "Release ${{ steps.version.outputs.tag }}" \
+              --generate-notes

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,10 +5,12 @@ plugins {
 }
 
 val lunaticlibVersion: String by lazy {
-    val tomlFile = file("gradle/libs.versions.toml")
-    val versionRegex = Regex("""de-janschuri-lunaticlib\s*=\s*"([^"]+)"""")
-    tomlFile.readLines()
-        .firstNotNullOf { versionRegex.find(it)?.groupValues?.get(1) }
+    providers.gradleProperty("lunaticlibVersion").orNull ?: run {
+        val tomlFile = file("gradle/libs.versions.toml")
+        val versionRegex = Regex("""de-janschuri-lunaticlib\s*=\s*"([^"]+)"""")
+        tomlFile.readLines()
+            .firstNotNullOf { versionRegex.find(it)?.groupValues?.get(1) }
+    }
 }
 extra["lunaticlibVersion"] = lunaticlibVersion
 
@@ -18,11 +20,45 @@ version = lunaticlibVersion
 repositories {
     mavenLocal()
     mavenCentral()
+    maven {
+        name = "papermc"
+        url = uri("https://repo.papermc.io/repository/maven-public/")
+    }
+}
+
+fun org.gradle.api.publish.PublishingExtension.configurePublishRepositories() {
+    repositories {
+        mavenLocal()
+
+        val githubActor = System.getenv("GITHUB_ACTOR")
+        val githubToken = System.getenv("GITHUB_TOKEN")
+        val githubRepository = System.getenv("GITHUB_REPOSITORY")
+
+        if (!githubActor.isNullOrBlank() && !githubToken.isNullOrBlank() && !githubRepository.isNullOrBlank()) {
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/$githubRepository")
+                credentials {
+                    username = githubActor
+                    password = githubToken
+                }
+            }
+        }
+    }
 }
 
 subprojects {
     apply(plugin = "java-library")
     apply(plugin = "maven-publish")
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven {
+            name = "papermc"
+            url = uri("https://repo.papermc.io/repository/maven-public/")
+        }
+    }
 
     publishing {
         publications {
@@ -30,10 +66,7 @@ subprojects {
                 from(components["java"])
             }
         }
-
-        repositories {
-            mavenLocal()
-        }
+        configurePublishRepositories()
     }
 }
 
@@ -121,9 +154,7 @@ publishing {
         }
     }
 
-    repositories {
-        mavenLocal()
-    }
+    configurePublishRepositories()
 }
 
 tasks.register("publishAllModulesToMavenLocal") {


### PR DESCRIPTION
### Motivation
- Fix CI compile failures where platform snapshot artifacts (for example `io.github.waterfallmc:waterfall-api:1.19-R0.1-SNAPSHOT`) were not found because root-level `repositories` were not applied broadly to subprojects.
- Reduce duplication and make publishing configuration reusable by centralizing GitHub Packages repository configuration.
- Allow an override for the project version via a Gradle property while keeping the existing `gradle/libs.versions.toml` fallback and add an automated release-and-publish workflow.

### Description
- Added the PaperMC Maven repository (`https://repo.papermc.io/repository/maven-public/`) to the root `repositories` block to allow resolution of platform/snapshot artifacts.
- Added the same PaperMC repository to the `subprojects` `repositories` block so all modules (including `:lunaticlib-sender-waterfall`) can resolve platform dependencies during CI builds.
- Introduced `configurePublishRepositories()` helper to centralize the GitHub Packages publishing repository configuration and applied it to root and subproject `publishing` blocks.
- Made `lunaticlibVersion` prefer the Gradle property `lunaticlibVersion` and fall back to parsing `gradle/libs.versions.toml`, and added the GitHub Actions workflow `.github/workflows/release-and-publish.yml` to compute versions, tag, build and publish artifacts.

### Testing
- CI prior to this change ran `./gradlew --no-daemon clean build` and failed at `:lunaticlib-sender-waterfall:compileJava` due to missing `waterfall-api` snapshot in the searched repositories, which motivated the fix.
- After the changes, an attempt to run `./gradlew --no-daemon :lunaticlib-sender-waterfall:compileJava` locally was blocked by the environment's proxy when downloading the Gradle wrapper distribution (`HTTP/1.1 403 Forbidden`), so full automated validation is deferred to the project CI.
- Basic file inspections of `build.gradle.kts` and the added workflow were performed to verify the repository and helper were inserted as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992459f99dc832884fbbff58aabcedc)